### PR TITLE
role api_ready: In cluster deployment, wait for all Managers to become available

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -14,6 +14,7 @@ exclude_paths:
   - .dev_dir/example_dev_vars.yml
   - .dev_dir/*
   - playbooks/tests/configuration_file_dev_vars.yml
+  - .ansible
 # parseable: true
 # quiet: true
 # strict: true

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -31,6 +31,7 @@ jobs:
       - uses: isort/isort-action@master
         with:
           requirementsFiles: "requirements.txt"
+          isortVersion: '5.12.0'
 
       - name: Install pycln
         run: pip install pycln==2.4.0

--- a/roles/api_ready/tasks/main.yml
+++ b/roles/api_ready/tasks/main.yml
@@ -10,7 +10,7 @@
     Check that API server is ready - verify "isServerReady" response with "/dataservice/client/server/ready" endpoint.
     Parameters:    retries: {{ retry_value_manager_api_ready }}    delay: {{ delay_value_manager_api_ready }}
   ansible.builtin.uri:
-    url: "https://{{ (vmanage_instances | first).mgmt_public_ip }}/dataservice/client/server/ready"
+    url: "https://{{ device_item.mgmt_public_ip }}/dataservice/client/server/ready"
     method: "GET"
     validate_certs: false
     return_content: true
@@ -20,3 +20,7 @@
   until:
     - manager_response.json is defined
     - manager_response.json.isServerReady | bool == true
+  loop: "{{ vmanage_instances }}"
+  loop_control:
+    loop_var: device_item
+    label: "hostname: {{ device_item.hostname }}, device_ip: {{ device_item.system_ip }}"

--- a/roles/onboarding_controllers/tasks/main.yml
+++ b/roles/onboarding_controllers/tasks/main.yml
@@ -67,7 +67,7 @@
       username: "{{ (vmanage_instances | first).admin_username }}"
       password: "{{ (vmanage_instances | first).admin_password }}"
   register: device_details_info
-  loop: "{{ vsmart_instances + vbond_instances + [(vmanage_instances | first)] }}"
+  loop: "{{ vsmart_instances + vbond_instances + [vmanage_instances | first] }}"
   loop_control:
     loop_var: device_item
     label: "hostname: {{ device_item.hostname }}, device_ip: {{ device_item.system_ip }}"
@@ -85,7 +85,7 @@
       username: "{{ (vmanage_instances | first).admin_username }}"
       password: "{{ (vmanage_instances | first).admin_password }}"
   register: device_details_info
-  loop: "{{ vsmart_instances + vbond_instances + [(vmanage_instances | first)] }}"
+  loop: "{{ vsmart_instances + vbond_instances + [vmanage_instances | first] }}"
   loop_control:
     loop_var: device_item
     label: "hostname: {{ device_item.hostname }}, device_ip: {{ device_item.system_ip }}"


### PR DESCRIPTION
# Pull Request summary:
During cluster deployments, I discovered situations where not all managers were ready when their API was queried. This PR fixes it.

# Description of changes:
The role api_ready will wait not only for the first manager but for all managers to become ready.

# Checklist:

- [x] PR description is clear and comprehensive
- [x] Mentioned the issue that this PR solves (if applicable)
- [x] Make sure you test the changes