### PR TITLE
feature_profile_builder: Update template profiles even when defaults are not set

### DIFF
--- a/plugins/modules/feature_profile_builder.py
+++ b/plugins/modules/feature_profile_builder.py
@@ -150,13 +150,12 @@ def get_settable_vars_for_profile(profile_type: str) -> SettableVars.Vars:
 
 def update_template(template, config: dict):
     for key, value in config.items():
-        if key in template:
-            if isinstance(value, dict) and isinstance(template[key], dict):
-                update_template(template[key], value)
-            else:
-                if isinstance(value, str) and value.startswith("{"):
-                    value = "{{ '" + value + "' }}"
-                template[key] = value
+        if key in template and isinstance(value, dict) and isinstance(template[key], dict):
+            update_template(template[key], value)
+        elif key in template or key == "value":
+            if isinstance(value, str) and value.startswith("{"):
+                value = "{{ '" + value + "' }}"
+            template[key] = value
 
 
 def append_settable_vars(config: dict, profile_type: str):


### PR DESCRIPTION
# Pull Request summary:
cisco.catalystwan.feature_profile_builder module is not able to update some parameters in profiles. It was discovered that mechanism that merges user input to profile templates updates only values that are already in default templates.

# Description of changes:
Merging mechanism was updated to accept copy values that don't have defaults in default templates

# Checklist:

- [x] PR description is clear and comprehensive
- [x] Mentioned the issue that this PR solves (if applicable)
- [x] Make sure you test the changes