### PR TITLE
software_upgrades: rename role, uploads from local machine

### DIFF
--- a/roles/software_upgrades/README.md
+++ b/roles/software_upgrades/README.md
@@ -1,21 +1,25 @@
-# Ansible Role: software_upgrades_remote
+# Ansible Role: software_upgrades
 
-This Ansible role is designed to perform software upgrades on Cisco SD-WAN devices using a remote server. It covers the entire workflow for upgrading vManage, vBond, vSmar devices using software images stored on a remote server configured with SCP.
+This Ansible role is designed to perform software upgrades on Cisco SD-WAN devices. Upgrade can be performed using images stored on remote server or by uploading images from local machine directly to vManage. Role covers the entire workflow for upgrading vManage, vBond, vSmart devices.
 
 ## Role Description
 
-The `software_upgrades_remote` role performs the following tasks:
+The `software_upgrades` role performs the following tasks:
 
 1. Verifies that required variables for the role are present.
-2. Informs the user to ensure the FTP server is correctly configured for remote server upgrades.
-3. Configures the remote server within Cisco vManage.
-4. Retrieves and validates the list of remote server repositories.
-5. Uploads software images from the remote server to the Cisco vManage software repository.
+2. (with remote server) Informs the user to ensure the FTP server is correctly configured for remote server upgrades.
+3. (with remote server) Configures the remote server within Cisco vManage.
+4. (with remote server) Retrieves and validates the list of remote server repositories.
+5. Uploads software images to the Cisco vManage software repository.
 6. Filters and asserts the presence of required software images in the vManage software repository.
 7. Executes software upgrade operations on vManage, vBond, and vSmart controllers.
 8. Sets the default software version on the controllers.
 9. Cleans up available software images from the controllers if desired.
 10. Verifies that the activated version is set as the current and default version.
+11. (with manual upload) Executes software upgrade operations on cEdges.
+12. (with manual upload) Sets the default software version on the cEdges.
+13. (with manual upload) Cleans up available software images from the cEdges if desired.
+14. (with manual upload) Verifies that the activated version is set as the current and default version.
 
 ## Requirements
 
@@ -31,11 +35,11 @@ There are no external role dependencies. Only `cisco.catalystwan` collection is 
 Variables expected by this role:
 
 - `vmanage_instances`: List of vManage instances containing management IP, admin username, and admin password.
-- `remote_server_name`: Name of the remote server to be used.
-- `remote_server_url`: URL of the remote server.
-- `remote_server_user`: Username for the remote server.
-- `remote_server_password`: Password for the remote server.
-- `remote_server_image_location_prefix`: Prefix for the image location on the remote server.
+- `remote_server_name`: Name of the remote server to be used. Only needed for upgrades with remote server.
+- `remote_server_url`: URL of the remote server. Only needed for upgrades with remote server.
+- `remote_server_user`: Username for the remote server. Only needed for upgrades with remote server.
+- `remote_server_password`: Password for the remote server. Only needed for upgrades with remote server.
+- `remote_server_image_location_prefix`: Prefix for the image location on the remote server. Only needed for upgrades with remote server.
 - `vmanage_remote_software_filename`: Software image filename for vManage.
 - `viptela_remote_software_filename`: Software image filename for vBond and vSmart.
 - `cedge_remote_software_filename`: Software image filename for cEdge.
@@ -51,9 +55,9 @@ Including an example of how to use your role (with variables passed in as parame
 - hosts: localhost
   gather_facts: no
   tasks:
-    - name: Run software_upgrades_remote
+    - name: Run software_upgrades
       import_role:
-        name: software_upgrades_remote
+        name: software_upgrades
       vars:
         vmanage_instances:
           - mgmt_public_ip: '192.0.2.1'
@@ -76,6 +80,7 @@ Including an example of how to use your role (with variables passed in as parame
 
 - The role assumes that controllers are <20.13 version.
 - Upgrades of cEdges from Remote Server are currently not included
+- When directly uploading images from local machine to vManage, upload of a single image must complete within Server Session Timeout
 
 ## License
 

--- a/roles/software_upgrades/meta/main.yml
+++ b/roles/software_upgrades/meta/main.yml
@@ -2,7 +2,7 @@
 
 galaxy_info:
   author: Arkadiusz Cichon <acichon@cisco.com>
-  description: Perform software upgrades of controllers and edges with Remote Server as repository
+  description: Perform software upgrades of controllers and edges
   license: GPL-3.0-or-later
   min_ansible_version: "2.16.6"
 

--- a/roles/software_upgrades/tasks/main.yml
+++ b/roles/software_upgrades/tasks/main.yml
@@ -10,108 +10,16 @@
 - name: "Verify required variables for selected role"
   ansible.builtin.include_tasks: variables_assertion.yml
 
-- name: "Inform user that in case of Remote Server configuration, provided paths cannot be verified by role"
-  ansible.builtin.pause:
-    prompt: |-
+- name: Set variables
+  ansible.builtin.set_fact:
+    upgrade_from_remote_server: "{{ remote_server_name is defined }}"
 
-      Please verify that your FTP server is correctly configured.
-
-      Press any key to continue, press `Ctrl + C` and `Shift + A` to abort
-  register: user_response
-
-
-# --- Remote server configuration --- #
-
-
-- name: "Configure Remote Server: {{ remote_server_name }}"
-  cisco.catalystwan.software_repository:
-    remote_server:
-      state: present
-      name: "{{ remote_server_name }}"
-      url: "{{ remote_server_url }}"
-      protocol: SCP
-      port: 22
-      vpn: 512
-      user: "{{ remote_server_user }}"
-      password: "{{ remote_server_password }}"
-      image_location_prefix: "{{ remote_server_image_location_prefix }}"
-    manager_authentication:
-      url: "{{ (vmanage_instances | first).mgmt_public_ip }}"
-      username: "{{ (vmanage_instances | first).admin_username }}"
-      password: "{{ (vmanage_instances | first).admin_password }}"
-  failed_when: false
-  changed_when: false
-
-- name: "Get list of all Remote Server repositories on Manager"
-  cisco.catalystwan.software_repository_info:
-    category: "remote_servers"
-    filters:
-      remote_server_name: "{{ remote_server_name }}"
-    manager_authentication:
-      url: "{{ (vmanage_instances | first).mgmt_public_ip }}"
-      username: "{{ (vmanage_instances | first).admin_username }}"
-      password: "{{ (vmanage_instances | first).admin_password }}"
-  register: remote_servers_info
-
-- name: "Debug all_remote_servers - expect one, and verify port is == 22"
-  ansible.builtin.assert:
-    that:
-      - remote_servers_info.remote_servers | length == 1
-      - ( remote_servers_info.remote_servers | first ).remote_server_name == remote_server_name
-      - ( remote_servers_info.remote_servers | first ).remote_server_port == 22
-    fail_msg: "Requested Remote Server not found in configured Remote Servers list"
-
-
-# --- Remote Server images upload --- #
-
-
-- name: |
-    Upload software image to Manager from Remote Server:
-    - {{ vmanage_remote_software_filename }}
-    - {{ viptela_remote_software_filename }}
-    - {{ cedge_remote_software_filename }}
-  cisco.catalystwan.software_repository:
-    software:
-      filename: "{{ filename_item }}"
-      remote_server_name: "{{ remote_server_name }}"
-    manager_authentication:
-      url: "{{ (vmanage_instances | first).mgmt_public_ip }}"
-      username: "{{ (vmanage_instances | first).admin_username }}"
-      password: "{{ (vmanage_instances | first).admin_password }}"
-  loop:
-    - "{{ vmanage_remote_software_filename }}"
-    - "{{ viptela_remote_software_filename }}"
-    - "{{ cedge_remote_software_filename }}"
-  loop_control:
-    loop_var: filename_item
-
-- name: "Filter list of all software images on Manager to find these from Remote Server"
-  cisco.catalystwan.software_repository_info:
-    category: "software_images"
-    filters:
-      version_type: "{{ remote_server_name }}"
-    manager_authentication:
-      url: "{{ (vmanage_instances | first).mgmt_public_ip }}"
-      username: "{{ (vmanage_instances | first).admin_username }}"
-      password: "{{ (vmanage_instances | first).admin_password }}"
-  register: software_images_info
-
-- name: "Assert that required images present on Manager Software Images list"
-  ansible.builtin.assert:
-    that:
-      - software_images_info.software_images | length == 3
-      - "{{ software_files_names | difference(software_basenames) | length == 0 }}"
-    fail_msg: |
-      Cannot find all required images, see:
-      all_available_files: {{ all_available_files }}, software_files_names: {{ software_files_names }}
-    success_msg: "All required files present on Manager Software Images list"
+# --- Upload images from local machine or remote server --- #
+- name: "Upload images from {{ upload_method }}"
+  ansible.builtin.include_tasks:
+    file: "{{ upload_method }}.yml"
   vars:
-    all_available_files: "{{ software_images_info.software_images | map(attribute='available_files') | list }}"
-    software_basenames: "{{ all_available_files | map('regex_replace', '^.*/([^/]+)$', '\\1') | list }}"
-    software_files_names:
-      - "{{ vmanage_remote_software_filename }}"
-      - "{{ viptela_remote_software_filename }}"
-      - "{{ cedge_remote_software_filename }}"
+    upload_method: "{{ upgrade_from_remote_server | ternary('upload_from_remote_server', 'upload_directly_to_manager') }}"
 
 
 # --- Upgrade operations on controllers --- #
@@ -119,12 +27,13 @@
 
 # --- vManage software upgrades --- #
 
-- name: "Install software on vManage, image: {{ vmanage_remote_software_filename }}"
+- name: "Install software on vManage, image: {{ vmanage_remote_software_filename | basename }}"
   cisco.catalystwan.software_upgrade:
     state: "present"
     reboot: false
-    remote_server_name: "{{ remote_server_name }}"
-    remote_image_filename: "{{ remote_server_image_location_prefix }}{{ vmanage_remote_software_filename }}"
+    image_path: "{{ omit if upgrade_from_remote_server else vmanage_remote_software_filename }}"
+    remote_server_name: "{{ remote_server_name if upgrade_from_remote_server else omit }}"
+    remote_image_filename: "{{ remote_server_image_location_prefix ~ vmanage_remote_software_filename if upgrade_from_remote_server else omit }}"
     downgrade_check: false
     wait_for_completed: true
     wait_timeout_seconds: 3600
@@ -137,12 +46,12 @@
 
 # FIXME image_path doesn't work because Remote images don't include version_name in repository
 - name: |
-    Activate software (include reboot) on vManage from software: {{ vmanage_remote_software_filename }}
+    Activate software (include reboot) on vManage from software: {{ vmanage_remote_software_filename | basename }}
     Version to activate: {{ controller_software_version_to_activate }}
   cisco.catalystwan.software_upgrade:
     state: "active"
-    # image_path: "{{ remote_server_image_location_prefix }}{{ vmanage_remote_software_filename }}"
-    image_version: "{{ controller_software_version_to_activate }}"
+    image_path: "{{ omit if upgrade_from_remote_server else vmanage_remote_software_filename | basename }}"
+    image_version: "{{ controller_software_version_to_activate if upgrade_from_remote_server else omit }}"
     wait_timeout_seconds: 3600
     filters:
       personality: "vmanage"
@@ -202,12 +111,13 @@
 # --- vBond software upgrades --- #
 
 
-- name: "Install and activate software operation on vBond, image: {{ viptela_remote_software_filename }}"
+- name: "Install and activate software operation on vBond, image: {{ viptela_remote_software_filename | basename }}"
   cisco.catalystwan.software_upgrade:
     state: "present"  # present with reboot: true -> ACTIVE in vManage
     reboot: true
-    remote_server_name: "{{ remote_server_name }}"
-    remote_image_filename: "{{ remote_server_image_location_prefix }}{{ viptela_remote_software_filename }}"
+    image_path: "{{ omit if upgrade_from_remote_server else viptela_remote_software_filename }}"
+    remote_server_name: "{{ remote_server_name if upgrade_from_remote_server else omit }}"
+    remote_image_filename: "{{ remote_server_image_location_prefix ~ viptela_remote_software_filename if upgrade_from_remote_server else omit }}"
     wait_for_completed: true
     wait_timeout_seconds: 3600
     downgrade_check: false
@@ -271,12 +181,13 @@
 # --- vSmart software upgrades --- #
 
 
-- name: "Install and activate software operation on vSmart, image: {{ viptela_remote_software_filename }}"
+- name: "Install and activate software operation on vSmart, image: {{ viptela_remote_software_filename | basename }}"
   cisco.catalystwan.software_upgrade:
     state: "present"  # present with reboot: true -> ACTIVE in vManage
     reboot: true
-    remote_server_name: "{{ remote_server_name }}"
-    remote_image_filename: "{{ remote_server_image_location_prefix }}{{ viptela_remote_software_filename }}"
+    image_path: "{{ omit if upgrade_from_remote_server else viptela_remote_software_filename }}"
+    remote_server_name: "{{ remote_server_name if upgrade_from_remote_server else omit }}"
+    remote_image_filename: "{{ remote_server_image_location_prefix ~ viptela_remote_software_filename if upgrade_from_remote_server else omit }}"
     wait_for_completed: true
     wait_timeout_seconds: 3600
     downgrade_check: false
@@ -339,12 +250,13 @@
 
 # --- vSmart software upgrades --- #
 
-- name: "Install and activate software operation on cEdges, image: {{ cedge_remote_software_filename }}"
+- name: "Install and activate software operation on cEdges, image: {{ cedge_remote_software_filename | basename }}"
   cisco.catalystwan.software_upgrade:
     state: "present"  # present with reboot: true -> ACTIVATE in vManage
     reboot: true
-    remote_server_name: "{{ remote_server_name }}"
-    remote_image_filename: "{{ remote_server_image_location_prefix }}{{ cedge_remote_software_filename }}"
+    image_path: "{{ omit if upgrade_from_remote_server else cedge_remote_software_filename }}"
+    remote_server_name: "{{ remote_server_name if upgrade_from_remote_server else omit }}"
+    remote_image_filename: "{{ remote_server_image_location_prefix ~ cedge_remote_software_filename if upgrade_from_remote_server else omit }}"
     wait_for_completed: true
     downgrade_check: false
     filters:

--- a/roles/software_upgrades/tasks/upload_directly_to_manager.yml
+++ b/roles/software_upgrades/tasks/upload_directly_to_manager.yml
@@ -1,0 +1,54 @@
+# Copyright 2024 Cisco Systems, Inc. and its affiliates
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+---
+
+# --- Upload images directly to Manager --- #
+
+
+- name: |
+    Upload software image to Manager:
+    - {{ vmanage_remote_software_filename }}
+    - {{ viptela_remote_software_filename }}
+    - {{ cedge_remote_software_filename }}
+  cisco.catalystwan.software_repository:
+    software:
+      image_path: "{{ filename_item }}"
+    manager_authentication:
+      url: "{{ (vmanage_instances | first).mgmt_public_ip }}"
+      username: "{{ (vmanage_instances | first).admin_username }}"
+      password: "{{ (vmanage_instances | first).admin_password }}"
+  loop:
+    - "{{ vmanage_remote_software_filename }}"
+    - "{{ viptela_remote_software_filename }}"
+    - "{{ cedge_remote_software_filename }}"
+  loop_control:
+    loop_var: filename_item
+
+- name: "Filter list of all software images on Manager to find these manually uploaded"
+  cisco.catalystwan.software_repository_info:
+    category: "software_images"
+    filters:
+      version_type: "vmanage"
+    manager_authentication:
+      url: "{{ (vmanage_instances | first).mgmt_public_ip }}"
+      username: "{{ (vmanage_instances | first).admin_username }}"
+      password: "{{ (vmanage_instances | first).admin_password }}"
+  register: software_images_info
+
+- name: "Assert that required images present on Manager Software Images list"
+  ansible.builtin.assert:
+    that:
+      - software_images_info.software_images | length == 3
+      - "{{ software_basenames | difference(all_available_files) | length == 0 }}"
+    fail_msg: |
+      Cannot find all required images, see:
+      all_available_files: {{ all_available_files }}, software_files_names: {{ software_files_names }}
+    success_msg: "All required files present on Manager Software Images list"
+  vars:
+    all_available_files: "{{ software_images_info.software_images | map(attribute='available_files') | list }}"
+    software_basenames: "{{ software_files_names | map('basename') | list }}"
+    software_files_names:
+      - "{{ vmanage_remote_software_filename }}"
+      - "{{ viptela_remote_software_filename }}"
+      - "{{ cedge_remote_software_filename }}"

--- a/roles/software_upgrades/tasks/upload_from_remote_server.yml
+++ b/roles/software_upgrades/tasks/upload_from_remote_server.yml
@@ -1,0 +1,107 @@
+# Copyright 2024 Cisco Systems, Inc. and its affiliates
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+---
+
+- name: "Inform user that in case of Remote Server configuration, provided paths cannot be verified by role"
+  ansible.builtin.pause:
+    prompt: |-
+
+      Please verify that your FTP server is correctly configured.
+
+      Press any key to continue, press `Ctrl + C` and `Shift + A` to abort
+  register: user_response
+
+
+# --- Remote server configuration --- #
+
+
+- name: "Configure Remote Server: {{ remote_server_name }}"
+  cisco.catalystwan.software_repository:
+    remote_server:
+      state: present
+      name: "{{ remote_server_name }}"
+      url: "{{ remote_server_url }}"
+      protocol: SCP
+      port: 22
+      vpn: 512
+      user: "{{ remote_server_user }}"
+      password: "{{ remote_server_password }}"
+      image_location_prefix: "{{ remote_server_image_location_prefix }}"
+    manager_authentication:
+      url: "{{ (vmanage_instances | first).mgmt_public_ip }}"
+      username: "{{ (vmanage_instances | first).admin_username }}"
+      password: "{{ (vmanage_instances | first).admin_password }}"
+  failed_when: false
+  changed_when: false
+
+- name: "Get list of all Remote Server repositories on Manager"
+  cisco.catalystwan.software_repository_info:
+    category: "remote_servers"
+    filters:
+      remote_server_name: "{{ remote_server_name }}"
+    manager_authentication:
+      url: "{{ (vmanage_instances | first).mgmt_public_ip }}"
+      username: "{{ (vmanage_instances | first).admin_username }}"
+      password: "{{ (vmanage_instances | first).admin_password }}"
+  register: remote_servers_info
+
+- name: "Debug all_remote_servers - expect one, and verify port is == 22"
+  ansible.builtin.assert:
+    that:
+      - remote_servers_info.remote_servers | length == 1
+      - ( remote_servers_info.remote_servers | first ).remote_server_name == remote_server_name
+      - ( remote_servers_info.remote_servers | first ).remote_server_port == 22
+    fail_msg: "Requested Remote Server not found in configured Remote Servers list"
+
+
+# --- Remote Server images upload --- #
+
+
+- name: |
+    Upload software image to Manager from Remote Server:
+    - {{ vmanage_remote_software_filename }}
+    - {{ viptela_remote_software_filename }}
+    - {{ cedge_remote_software_filename }}
+  cisco.catalystwan.software_repository:
+    software:
+      filename: "{{ filename_item }}"
+      remote_server_name: "{{ remote_server_name }}"
+    manager_authentication:
+      url: "{{ (vmanage_instances | first).mgmt_public_ip }}"
+      username: "{{ (vmanage_instances | first).admin_username }}"
+      password: "{{ (vmanage_instances | first).admin_password }}"
+  loop:
+    - "{{ vmanage_remote_software_filename }}"
+    - "{{ viptela_remote_software_filename }}"
+    - "{{ cedge_remote_software_filename }}"
+  loop_control:
+    loop_var: filename_item
+
+- name: "Filter list of all software images on Manager to find these from Remote Server"
+  cisco.catalystwan.software_repository_info:
+    category: "software_images"
+    filters:
+      version_type: "{{ remote_server_name }}"
+    manager_authentication:
+      url: "{{ (vmanage_instances | first).mgmt_public_ip }}"
+      username: "{{ (vmanage_instances | first).admin_username }}"
+      password: "{{ (vmanage_instances | first).admin_password }}"
+  register: software_images_info
+
+- name: "Assert that required images present on Manager Software Images list"
+  ansible.builtin.assert:
+    that:
+      - software_images_info.software_images | length == 3
+      - "{{ software_files_names | difference(software_basenames) | length == 0 }}"
+    fail_msg: |
+      Cannot find all required images, see:
+      all_available_files: {{ all_available_files }}, software_files_names: {{ software_files_names }}
+    success_msg: "All required files present on Manager Software Images list"
+  vars:
+    all_available_files: "{{ software_images_info.software_images | map(attribute='available_files') | list }}"
+    software_basenames: "{{ all_available_files | map('regex_replace', '^.*/([^/]+)$', '\\1') | list }}"
+    software_files_names:
+      - "{{ vmanage_remote_software_filename }}"
+      - "{{ viptela_remote_software_filename }}"
+      - "{{ cedge_remote_software_filename }}"

--- a/roles/software_upgrades/tasks/variables_assertion.yml
+++ b/roles/software_upgrades/tasks/variables_assertion.yml
@@ -19,12 +19,33 @@
     - "{{ cedge_remote_software_filename }}"
     - "{{ vmanage_remote_software_filename }}"
     - "{{ viptela_remote_software_filename }}"
+    - "{{ controller_software_version_to_activate }}"
+    - "{{ edge_software_version_to_activate }}"
+  loop_control:
+    loop_var: required_var
+
+- name: Assert that remote_server variables are provided
+  ansible.builtin.assert:
+    that:
+      - required_var
+      - required_var is defined
+      - required_var != None
+      - required_var != "None"
+      - required_var != ""
+      - required_var | length > 0
+    fail_msg: "Your SD-WAN config file missing required variable: {{ required_var }}"
+    quiet: true
+  loop:
     - "{{ remote_server_name }}"
     - "{{ remote_server_url }}"
     - "{{ remote_server_user }}"
     - "{{ remote_server_password }}"
     - "{{ remote_server_image_location_prefix }}"
-    - "{{ controller_software_version_to_activate }}"
-    - "{{ edge_software_version_to_activate }}"
   loop_control:
     loop_var: required_var
+  when: >
+    remote_server_name is defined
+    or remote_server_url is defined
+    or remote_server_user is defined
+    or remote_server_password is defined
+    or remote_server_image_location_prefix is defined


### PR DESCRIPTION
# Pull Request summary:
This PR enable user to perform upgrades without remote server. Images are uploaded directly into Manager

# Description of changes:
software_upgrades_remote role changes name to software_upgrades. When user provides remote_server variables, software upgrade with remote server will be conducted. Otherwise images with provided filenames will be uploaded into Manager.

# Checklist:

- [x] PR description is clear and comprehensive
- [x] Mentioned the issue that this PR solves (if applicable)
- [x] Make sure you test the changes