### PR TITLE
sync_pnp_edges: Generate bootstrap only for edged that require it

### DIFF
--- a/roles/sync_pnp_edges/tasks/main.yml
+++ b/roles/sync_pnp_edges/tasks/main.yml
@@ -39,9 +39,19 @@
       password: "{{ (vmanage_instances | first).admin_password }}"
   when: wan_edge_list_path is not defined
 
+- name: Get list of Edge devices
+  cisco.catalystwan.devices_info:
+    device_category: vedges
+    manager_authentication:
+      url: "{{ (vmanage_instances | first).mgmt_public_ip }}"
+      username: "{{ (vmanage_instances | first).admin_username }}"
+      password: "{{ (vmanage_instances | first).admin_password }}"
+  register: all_edge_devices
+
 - name: Generate bootstrap configuration for all devices
   cisco.catalystwan.devices_wan_edges:
     generate_bootstrap_configuration: true
+    uuid: "{{ (all_edge_devices['devices'] | selectattr('cert_install_status', '!=', 'Installed')) | map(attribute='uuid') }}"
     manager_authentication:
       url: "{{ (vmanage_instances | first).mgmt_public_ip }}"
       username: "{{ (vmanage_instances | first).admin_username }}"


### PR DESCRIPTION
# Pull Request summary:
Solve issue https://github.com/cisco-en-programmability/ansible-collection-sdwan/issues/19

# Description of changes:
To generate bootstrap configurations for Edge devices, first get a list of all Edge devices and then proceed to generate bootstrap configurations only for those that have not been initialized.

# Checklist:

- [x] PR description is clear and comprehensive
- [x] Mentioned the issue that this PR solves (if applicable)
- [x] Make sure you test the changes