### PR TITLE
When executed task fails return detailed status of subtasks

### DIFF
--- a/plugins/module_utils/vmanage_module.py
+++ b/plugins/module_utils/vmanage_module.py
@@ -245,6 +245,7 @@ class AnsibleCatalystwanModule:
 
                 else:
                     result.changed = False
+                    result.response = [task.dict() for task in task_result.sub_tasks_data]
                     result.msg = failure_msg
                     self.fail_json(**result.model_dump(mode="json"))
             else:


### PR DESCRIPTION
# Pull Request summary:
Fixes https://github.com/cisco-en-programmability/ansible-collection-catalystwan/issues/14

# Description of changes:
The execute_action_safely function will return a comprehensive response detailing the outcomes of subtasks when the executed task fails.

# Checklist:

- [x] PR description is clear and comprehensive
- [x] Mentioned the issue that this PR solves (if applicable)
- [x] Make sure you test the changes