### PR TITLE
AWS: Allow the deployment of a subset of edges

### DIFF
--- a/roles/activate_edges/tasks/main.yml
+++ b/roles/activate_edges/tasks/main.yml
@@ -76,3 +76,6 @@
   until:
     - edge_device_details.devices[0].cert_install_status == "Installed"
     - edge_device_details.devices[0].reachability == "reachable"
+  when: >
+    wan_edges is not defined
+    or wan_edges | json_query('[?uuid==`'~device_item['uuid']~'`] | [?!contains(keys(@), `foreign`) || !foreign || contains(keys(@), `mgmt_public_ip`)]')


### PR DESCRIPTION
# Pull Request summary:
Changes required for https://github.com/cisco-en-programmability/ansible-collection-sdwan/pull/39

# Description of changes:
Adjust activate_edges role behavior to new wan_edges config variable.

# Checklist:

- [x] PR description is clear and comprehensive
- [x] Mentioned the issue that this PR solves (if applicable)
- [x] Make sure you test the changes