### PR TITLE
Fix for Enterprise CA in in cluster deployment

### DIFF
--- a/roles/onboarding_controllers/tasks/certificates.yml
+++ b/roles/onboarding_controllers/tasks/certificates.yml
@@ -30,5 +30,5 @@
     install_signed_certificate: "{{ signed_cert['certificate'] }}"
     manager_authentication:
       url: "{{ mgmt_url }}"
-      username: "{{ (vmanage_instances | first).admin_username }}"
-      password: "{{ (vmanage_instances | first).admin_password }}"
+      username: "{{ mgmt_admin_username }}"
+      password: "{{ mgmt_admin_password }}"

--- a/roles/onboarding_controllers/tasks/certificates.yml
+++ b/roles/onboarding_controllers/tasks/certificates.yml
@@ -29,6 +29,6 @@
   cisco.catalystwan.devices_certificates:
     install_signed_certificate: "{{ signed_cert['certificate'] }}"
     manager_authentication:
-      url: "{{ (vmanage_instances | first).mgmt_public_ip }}"
+      url: "{{ mgmt_url }}"
       username: "{{ (vmanage_instances | first).admin_username }}"
       password: "{{ (vmanage_instances | first).admin_password }}"

--- a/roles/onboarding_controllers/tasks/main.yml
+++ b/roles/onboarding_controllers/tasks/main.yml
@@ -35,6 +35,7 @@
   vars:
     csr_content: "{{ (csr_item['response']['generate_csr'] | first)['deviceCSR'] }}"
     csr_system_ip: "{{ csr_item.device_item.system_ip }}"
+    mgmt_url: "{{ csr_item.device_item.mgmt_public_ip }}"
 
 - name: Add vSmart devices
   cisco.catalystwan.devices_controllers:
@@ -87,6 +88,7 @@
   vars:
     csr_content: "{{ (csr_item['response']['generate_csr'] | first)['deviceCSR'] }}"
     csr_system_ip: "{{ csr_item.device_item.device_item.system_ip }}"
+    mgmt_url: "{{ (vmanage_instances | first).mgmt_public_ip }}"
 
 - name: Add vBond devices
   cisco.catalystwan.devices_controllers:
@@ -141,6 +143,7 @@
   vars:
     csr_content: "{{ (csr_item['response']['generate_csr'] | first)['deviceCSR'] }}"
     csr_system_ip: "{{ csr_item.device_item.device_item.system_ip }}"
+    mgmt_url: "{{ (vmanage_instances | first).mgmt_public_ip }}"
 
 - name: Wait until all controller devices are discoverable via system ip
   cisco.catalystwan.devices_info:

--- a/roles/onboarding_controllers/tasks/main.yml
+++ b/roles/onboarding_controllers/tasks/main.yml
@@ -36,6 +36,8 @@
     csr_content: "{{ (csr_item['response']['generate_csr'] | first)['deviceCSR'] }}"
     csr_system_ip: "{{ csr_item.device_item.system_ip }}"
     mgmt_url: "{{ csr_item.device_item.mgmt_public_ip }}"
+    mgmt_admin_username: "{{ csr_item.device_item.admin_username }}"
+    mgmt_admin_password: "{{ csr_item.device_item.admin_password }}"
 
 - name: Add vSmart devices
   cisco.catalystwan.devices_controllers:
@@ -89,6 +91,8 @@
     csr_content: "{{ (csr_item['response']['generate_csr'] | first)['deviceCSR'] }}"
     csr_system_ip: "{{ csr_item.device_item.device_item.system_ip }}"
     mgmt_url: "{{ (vmanage_instances | first).mgmt_public_ip }}"
+    mgmt_admin_username: "{{ (vmanage_instances | first).admin_username }}"
+    mgmt_admin_password: "{{ (vmanage_instances | first).admin_password }}"
 
 - name: Add vBond devices
   cisco.catalystwan.devices_controllers:
@@ -144,6 +148,8 @@
     csr_content: "{{ (csr_item['response']['generate_csr'] | first)['deviceCSR'] }}"
     csr_system_ip: "{{ csr_item.device_item.device_item.system_ip }}"
     mgmt_url: "{{ (vmanage_instances | first).mgmt_public_ip }}"
+    mgmt_admin_username: "{{ (vmanage_instances | first).admin_username }}"
+    mgmt_admin_password: "{{ (vmanage_instances | first).admin_password }}"
 
 - name: Wait until all controller devices are discoverable via system ip
   cisco.catalystwan.devices_info:


### PR DESCRIPTION
# Pull Request summary:
Enterprise CA was not set correctly. This PR fixes it. For all certificate managing operations, ansible will connect to first Manager

# Checklist:

- [x] PR description is clear and comprehensive
- [x] Mentioned the issue that this PR solves (if applicable)
- [x] Make sure you test the changes