### PR TITLE
Add dual stack address verification after software upgrade

### DIFF
--- a/roles/software_upgrades/tasks/main.yml
+++ b/roles/software_upgrades/tasks/main.yml
@@ -320,18 +320,19 @@
 - name: Verify that IPv4 dual stack addresses are reachable
   ansible.builtin.command:
     cmd: "ping -c 4 {{ item }}"
-  loop: "{{ (deployed_edge_instances | map(attribute='mgmt_public_ip') | list)
-           + (deployed_edge_instances | map(attribute='transport_public_ip') | list) }}"
+  loop: "{{ ((deployed_edge_instances | default([]) | map(attribute='mgmt_public_ip') | list)
+           + (deployed_edge_instances | default([]) | map(attribute='transport_public_ip') | list))
+           | select('truthy') | list }}"
   changed_when: false
 
 - name: Verify that IPv6 dual stack addresses are reachable
   ansible.builtin.command:
     cmd: "ping6 -c 4 {{ _edge_instance[_ipv6_attribute] }}"
-  loop: "{{ deployed_edge_instances | product(['mgmt_public_ipv6', 'transport_public_ipv6']) }}"
+  loop: "{{ deployed_edge_instances | default([]) | product(['mgmt_public_ipv6', 'transport_public_ipv6']) }}"
   loop_control:
     label: "{{ _edge_instance['hostname'] }} - {{ _ipv6_attribute }}"
   vars:
     _edge_instance: "{{ item.0 }}"
     _ipv6_attribute: "{{ item.1 }}"
-  when: _ipv6_attribute in _edge_instance
+  when: _ipv6_attribute in _edge_instance and _edge_instance[_ipv6_attribute]
   changed_when: false

--- a/roles/software_upgrades/tasks/main.yml
+++ b/roles/software_upgrades/tasks/main.yml
@@ -326,7 +326,12 @@
 
 - name: Verify that IPv6 dual stack addresses are reachable
   ansible.builtin.command:
-    cmd: "ping6 -c 4 {{ item }}"
-  loop: "{{ (deployed_edge_instances | map(attribute='mgmt_public_ipv6') | list)
-             + (deployed_edge_instances | map(attribute='transport_public_ipv6') | list) }}"
+    cmd: "ping6 -c 4 {{ _edge_instance[_ipv6_attribute] }}"
+  loop: "{{ deployed_edge_instances | product(['mgmt_public_ipv6', 'transport_public_ipv6']) }}"
+  loop_control:
+    label: "{{ _edge_instance['hostname'] }} - {{ _ipv6_attribute }}"
+  vars:
+    _edge_instance: "{{ item.0 }}"
+    _ipv6_attribute: "{{ item.1 }}"
+  when: _ipv6_attribute in _edge_instance
   changed_when: false

--- a/roles/software_upgrades/tasks/main.yml
+++ b/roles/software_upgrades/tasks/main.yml
@@ -316,3 +316,17 @@
   loop: "{{ software_info_cedges.installed_devices }}"
   loop_control:
     loop_var: device_item
+
+- name: Verify that IPv4 dual stack addresses are reachable
+  ansible.builtin.command:
+    cmd: "ping -c 4 {{ item }}"
+  loop: "{{ (deployed_edge_instances | map(attribute='mgmt_public_ip') | list)
+           + (deployed_edge_instances | map(attribute='transport_public_ip') | list) }}"
+  changed_when: false
+
+- name: Verify that IPv6 dual stack addresses are reachable
+  ansible.builtin.command:
+    cmd: "ping6 -c 4 {{ item }}"
+  loop: "{{ (deployed_edge_instances | map(attribute='mgmt_public_ipv6') | list)
+             + (deployed_edge_instances | map(attribute='transport_public_ipv6') | list) }}"
+  changed_when: false

--- a/roles/software_upgrades/tasks/upload_from_remote_server.yml
+++ b/roles/software_upgrades/tasks/upload_from_remote_server.yml
@@ -60,8 +60,8 @@
       - target_remote_server_edge | list | length > 0
       - (target_remote_server_edge | list | first).remote_server_port == 22
   vars:
-    target_remote_server: "{{ remote_servers_info.remote_servers | selectattr('remote_server_name', 'equalto', remote_server_name) }}"
-    target_remote_server_edge: "{{ remote_servers_info.remote_servers | selectattr('remote_server_name', 'equalto', remote_server_name~'-edge') }}"
+    target_remote_server: "{{ remote_servers_info.remote_servers | selectattr('remote_server_name', 'equalto', remote_server_name) | list }}"
+    target_remote_server_edge: "{{ remote_servers_info.remote_servers | selectattr('remote_server_name', 'equalto', remote_server_name~'-edge') | list }}"
 
 
 # --- Remote Server images upload --- #

--- a/roles/software_upgrades/tasks/upload_from_remote_server.yml
+++ b/roles/software_upgrades/tasks/upload_from_remote_server.yml
@@ -51,15 +51,17 @@
       password: "{{ (vmanage_instances | first).admin_password }}"
   register: remote_servers_info
 
-- name: "Debug all_remote_servers - expect two, and verify port is == 22"
+- name: "Verify remote servers configuration - expect two, and port is 22"
   ansible.builtin.assert:
     that:
       - remote_servers_info.remote_servers | length == 2
-      - ( remote_servers_info.remote_servers | first ).remote_server_name == remote_server_name
-      - ( remote_servers_info.remote_servers | first ).remote_server_port == 22
-      - ( remote_servers_info.remote_servers | last ).remote_server_name == remote_server_name~'-edge'
-      - ( remote_servers_info.remote_servers | last ).remote_server_port == 22
-    fail_msg: "Requested Remote Server not found in configured Remote Servers list"
+      - target_remote_server | list | length > 0
+      - (target_remote_server | list | first).remote_server_port == 22
+      - target_remote_server_edge | list | length > 0
+      - (target_remote_server_edge | list | first).remote_server_port == 22
+  vars:
+    target_remote_server: "{{ remote_servers_info.remote_servers | selectattr('remote_server_name', 'equalto', remote_server_name) }}"
+    target_remote_server_edge: "{{ remote_servers_info.remote_servers | selectattr('remote_server_name', 'equalto', remote_server_name~'-edge') }}"
 
 
 # --- Remote Server images upload --- #


### PR DESCRIPTION
# Pull Request summary:
After software upgrade completes, check all IPv4 and IPv6 addresses of edge devices.

# Checklist:

- [x] PR description is clear and comprehensive
- [x] Mentioned the issue that this PR solves (if applicable)
- [x] Make sure you test the changes